### PR TITLE
Swap margin / padding for larger focus area

### DIFF
--- a/paper-input-decorator.css
+++ b/paper-input-decorator.css
@@ -20,8 +20,8 @@ polyfill-next-selector {
 }
 ::content > *,
 ::content > input[is="core-input"] {
-  padding: 0;
-  margin: 0.5em 0 0.25em;
+  margin: 0;
+  padding: 0.5em 0 0.25em;
   width: 100%;
 }
 


### PR DESCRIPTION
Using margin for spacing creates gaps in the `paper-input-decorator` area that animate when clicked, but don't focus the input. Using padding increases the input focus click area to better match the `paper-input-decorator`.
