### PR TITLE
Break long words in mirror (paper-autogrow-textarea)

### DIFF
--- a/paper-autogrow-textarea.html
+++ b/paper-autogrow-textarea.html
@@ -46,6 +46,7 @@ Example:
 
     .mirror-text {
       visibility: hidden;
+      word-wrap: break-word;
     }
 
     ::content textarea {

--- a/test/autogrow.html
+++ b/test/autogrow.html
@@ -124,6 +124,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(getComputedStyle(a1.$.mirror).visibility, 'hidden');
       });
 
+      test('grows with a long word', function(done) {
+        var h1 = a1.offsetHeight;
+
+        t1.value = Array(1000).join("P");
+        dispatchInputEvent(t1);
+
+        flush(function() {
+          var h2 = a1.offsetHeight;
+          assert.ok(h2 > h1);
+          assert.deepEqual(a1.getBoundingClientRect(), t1.getBoundingClientRect());
+          done();
+        });
+      });
+
     });
 
   </script>


### PR DESCRIPTION
Fixes #108 

@morethanreal made another solution in  2f4c286 (I didn't test it), but I think that it's better to break the words like a normal textareas.
