### PR TITLE
valueForMirror in autogrow-textarea now replaces spaces with &nbsp;

### DIFF
--- a/paper-autogrow-textarea.html
+++ b/paper-autogrow-textarea.html
@@ -131,7 +131,7 @@ Example:
     },
 
     valueForMirror: function(input) {
-      this.tokens = (input && input.value) ? input.value.replace(/&/gm, '&amp;').replace(/"/gm, '&quot;').replace(/'/gm, '&#39;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;').split('\n') : [''];
+      this.tokens = (input && input.value) ? input.value.replace(/ /gm, '&nbsp;').replace(/&/gm, '&amp;').replace(/"/gm, '&quot;').replace(/'/gm, '&#39;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;').split('\n') : [''];
       return this.constrain(this.tokens);
     },
 


### PR DESCRIPTION
If a line starts with a space, the mirror does not offset properly.

![screen shot 2014-11-23 at 4 02 52 pm](https://cloud.githubusercontent.com/assets/916259/5159840/39d242f6-732a-11e4-9812-b9e6810f26b9.png)
![screen shot 2014-11-23 at 4 03 05 pm](https://cloud.githubusercontent.com/assets/916259/5159839/39ce1910-732a-11e4-84d1-bb426b6eea08.png)

This modifies the valueForMirror function to replace spaces with `&nbsp;`.
