### PR TITLE
allow calling update() with no arguments and make the published 'target' attribute work as expected

### DIFF
--- a/paper-autogrow-textarea.html
+++ b/paper-autogrow-textarea.html
@@ -34,7 +34,7 @@ Example:
 
 <link href="../polymer/polymer.html" rel="import">
 
-<polymer-element name="paper-autogrow-textarea" on-input="{{inputAction}}">
+<polymer-element name="paper-autogrow-textarea">
 <template>
 
   <style>
@@ -111,6 +111,39 @@ Example:
 
     tokens: null,
 
+    _isAttached: false,
+
+    _boundUpdate: null,
+
+    _getBoundUpdate: function() {
+      this._boundUpdate = this._boundUpdate || this.update.bind(this);
+      return this._boundUpdate;
+    },
+
+    attached: function() {
+      this._isAttached = true;
+      if (!this.target) return;
+      this.target.addEventListener('input', this._getBoundUpdate());
+    },
+
+    domReady: function() {
+      if (this.target) return;
+      this.target = this.querySelector('textarea');
+    },
+
+    detached: function() {
+      this._isAttached = false;
+      if (!this.target) return;
+      this.target.removeEventListener('input', this._getBoundUpdate());
+    },
+
+    targetChanged: function(oldVal, newVal) {
+      this.update();
+      if (!this._isAttached) return;
+      if (oldVal) oldVal.removeEventListener('input', this._getBoundUpdate());
+      if (newVal) newVal.addEventListener('input', this._getBoundUpdate());
+    },
+
     observe: {
       rows: 'updateCached',
       maxRows: 'updateCached'
@@ -131,8 +164,8 @@ Example:
       return _tokens.join('<br>') + '&nbsp;';
     },
 
-    valueForMirror: function(input) {
-      this.tokens = (input && input.value) ? input.value.replace(/&/gm, '&amp;').replace(/"/gm, '&quot;').replace(/'/gm, '&#39;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;').split('\n') : [''];
+    valueForMirror: function() {
+      this.tokens = (this.target && this.target.value) ? this.target.value.replace(/&/gm, '&amp;').replace(/"/gm, '&quot;').replace(/'/gm, '&#39;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;').split('\n') : [''];
       return this.constrain(this.tokens);
     },
 
@@ -142,18 +175,13 @@ Example:
      * is updated imperatively.
      *
      * @method update
-     * @param Element The input
      */
-    update: function(input) {
-      this.$.mirror.innerHTML = this.valueForMirror(input);
+    update: function() {
+      this.$.mirror.innerHTML = this.valueForMirror();
     },
 
     updateCached: function() {
       this.$.mirror.innerHTML = this.constrain(this.tokens);
-    },
-
-    inputAction: function(e) {
-      this.update(e.target);
     }
 
   });

--- a/test/paper-autogrow-textarea.html
+++ b/test/paper-autogrow-textarea.html
@@ -35,14 +35,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <textarea id="textarea1"></textarea>
   </paper-autogrow-textarea>
 
-  <paper-autogrow-textarea id="autogrow2" rows="2" maxRows="4">
-    <textarea id="textarea2"></textarea>
-  </paper-autogrow-textarea>
+  <paper-autogrow-textarea id="autogrow2"></paper-autogrow-textarea>
+  <textarea id="textarea2"></textarea>
+
+  <polymer-element name="test-bind" noscript>
+    <template>
+      <paper-autogrow-textarea id="autogrow" target="{{$.textarea}}">
+      </paper-autogrow-textarea>
+      <textarea id="textarea"></textarea>
+    </template>
+  </polymer-element>
+  <test-bind id="testBind"></test-bind>
 
   <script>
 
     var a1 = document.getElementById('autogrow1');
     var t1 = document.getElementById('textarea1');
+    var a2 = document.getElementById('autogrow2');
+    var t2 = document.getElementById('textarea2');
+    var tB = document.getElementById('testBind');
 
     function dispatchInputEvent(target) {
       var e = new Event('input', {
@@ -58,10 +69,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('basic', function() {
 
       teardown(function(done) {
-        t1.value = '';
-        dispatchInputEvent(t1);
-        a1.rows = 1;
-        a1.maxRows = 0;
+        var textareas = document.querySelectorAll('html /deep/ textarea');
+        for (var i = 0; i < textareas.length; i++) {
+          textareas[i].value = '';
+          dispatchInputEvent(textareas[i]);
+        }
+
+        var autogrows =
+            document.querySelectorAll('html /deep/ paper-autogrow-textarea');
+        for (var i = 0; i < autogrows.length; i++) {
+          autogrows[i].rows = 1;
+          autogrows[i].maxRows = 0;
+        }
+
+        a2.target = null;
 
         flush(function() {
           done();
@@ -134,6 +155,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var h2 = a1.offsetHeight;
           assert.ok(h2 > h1);
           assert.deepEqual(a1.getBoundingClientRect(), t1.getBoundingClientRect());
+          done();
+        });
+      });
+
+      test('can update size by calling update with no arguments', function() {
+        var h1 = a1.offsetHeight;
+        t1.value = 'one\ntwo\nthree';
+        a1.update();
+        assert.equal(a1.offsetHeight, h1 * 3);
+      });
+
+      test('can set the target programatically', function() {
+        var h1 = a2.offsetHeight;
+        a2.target = t2;
+        t2.value = 'one\ntwo';
+        a2.update();
+        assert.equal(a2.offsetHeight, h1 * 2);
+      });
+
+      test('can set the target with a binding', function() {
+        var a = tB.$.autogrow;
+        var t = tB.$.textarea;
+        var h1 = a.offsetHeight;
+        t.value = 'one\ntwo';
+        a.update();
+        assert.equal(a.offsetHeight, h1 * 2);
+      });
+
+      test('cleans up event listeners when detached', function(done) {
+        var h1 = a1.offsetHeight;
+        t1.value = 'one\ntwo\nthree';
+
+        // Remove it during the event dispatch.
+        a1.remove();
+        dispatchInputEvent(t1);
+        document.body.appendChild(a1);
+
+        flush(function() {
+          assert.equal(a1.offsetHeight, h1);
           done();
         });
       });


### PR DESCRIPTION
Fixes https://github.com/dart-lang/paper-elements/issues/79.

Another much simpler option here would be to just remove the 'target' attribute entirely (it wasn't being used at all before), and default do doing a querySelector('textarea') (or maybe even querySelectorAll?) inside the update method if input is not supplied.

Let me know if you would prefer that solution and I am happy to send out a new pull request. I don't know if having a bindable/assignable 'target' property is really necessary or desirable.