### PR TITLE
Added option for static error messages to prevent jumping content (Issue #130)

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -167,7 +167,7 @@
 
     <div>Auto-Validation</div>
 
-    <paper-input-decorator label="required" floatingLabel error="input is required!" autoValidate>
+    <paper-input-decorator label="required" floatingLabel error="input is required!" hasError autoValidate>
       <input is="core-input" required>
     </paper-input-decorator>
 

--- a/paper-input-decorator.html
+++ b/paper-input-decorator.html
@@ -204,9 +204,9 @@ conflict with this element.
       <div id="focusedUnderline" class="focused-underline" fit invisible?="{{!underlineVisible}}" animated?="{{underlineAnimated}}"></div>
     </div>
 
-    <div class="error" layout horizontal center hidden?="{{!isInvalid}}">
-      <div class="error-text" flex auto role="alert" aria-hidden="{{!isInvalid}}">{{error}}</div>
-      <core-icon class="error-icon" icon="warning"></core-icon>
+    <div class="error" layout horizontal center hidden?="{{!hasError}}">
+      <div class="error-text" flex auto role="alert" invisible?="{{!isInvalid}}" aria-hidden="{{!isInvalid}}">{{error}}</div>
+      <core-icon class="error-icon" invisible?="{{!isInvalid}}" icon="warning"></core-icon>
     </div>
 
   </template>
@@ -295,6 +295,17 @@ conflict with this element.
          * @type string
          */
         error: '',
+
+        /**
+         * Set this if you will use an error message for validation.
+         * If set, the error field will not collapse, which means content next to and
+         * below will not shift on changing validation. If false and content is invalid,
+         * underline turns red, but no error is displayed.
+         *
+         * @attribute hasError
+         * @type boolean
+         */
+        hasError: false,
 
         focused: {value: false, reflect: true}
 


### PR DESCRIPTION
tl;dr: jumpy text is ugly.
Problem: When content is invalid, an error message in unhidden. This makes inline content, content below, and possibly content above (if wrapped) jump down (see current demo). This is bad because the position of surrounding text should not depend on the validation of a field. 

Solution: Set error to be invisible instead of hidden.

Steps taken:
Added a hasError attribute (default: false).
If false and content is valid (or validation not checked), nothing changes.
If false and content is invalid, underline turns red & error message remains hidden.
If true and content is valid (or validation not checked), error field is invisible (error not shown, but takes up space)
If true and content is invalid, underline turns red & error message is visible.

Methodology:
My first thought was to base this off the value of 'error' (ie if error is null, do nothing, if error is present, add a static-height error field). Unfortunately, this approach is not modular because the 'error' value and validation could be set dynamically by a template engine post-polymer. 
