### PR TITLE
Add a paper-input-decorator password demo

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -148,6 +148,12 @@
 
     <br>
 
+    <paper-input-decorator label="with password" floatingLabel>
+      <input is="core-input" type="password">
+    </paper-input-decorator>
+
+    <br>
+
     <paper-input-decorator label="with autogrowing text area">
       <paper-autogrow-textarea>
         <textarea></textarea>


### PR DESCRIPTION
Developers often get [confused](https://github.com/Polymer/paper-input/issues/21) about how to create a `paper-input` instance with support for passwords. This adds a quick `paper-input-decorator` example to the demos showing them how to achieve this. 
