### PR TITLE
Raised input

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,8 @@
     "core-icon": "Polymer/core-icon#master",
     "core-icons": "Polymer/core-icons#master",
     "core-input": "Polymer/core-input#master",
-    "core-style": "Polymer/core-style#master"
+    "core-style": "Polymer/core-style#master",
+    "paper-shadow": "Polymer/paper-shadow#master"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^1.0.0"

--- a/demo.html
+++ b/demo.html
@@ -111,7 +111,17 @@
 
 </head>
 <body unresolved>
-
+  <section>
+    <div>Raised</div>
+    <paper-input label="label" raised></paper-input>
+    <br />
+    <paper-input label="floating label does not work with raised input" raised floatingLabel></paper-input>
+    <br />
+    <paper-input label="disabled" raised disabled></paper-input>
+    <paper-input-decorator label="required" error="input is required!" raised autoValidate>
+      <input is="core-input" required>
+    </paper-input-decorator>
+  </section>
   <section>
 
     <div>Standalone</div>

--- a/paper-input-decorator.html
+++ b/paper-input-decorator.html
@@ -128,6 +128,7 @@ conflict with this element.
 <link href="../core-icons/core-icons.html" rel="import">
 <link href="../core-input/core-input.html" rel="import">
 <link href="../core-style/core-style.html" rel="import">
+<link href="../paper-shadow/paper-shadow.html" rel="import">
 
 <core-style id="paper-input-decorator">
 
@@ -183,38 +184,70 @@ conflict with this element.
 
     <link href="paper-input-decorator.css" rel="stylesheet">
     <core-style ref="paper-input-decorator"></core-style>
+    <template if="{{!raised}}">
+      <div class="floated-label" aria-hidden="true" hidden?="{{!floatingLabel}}" invisible?="{{!floatingLabelVisible || labelAnimated}}">
+        <!-- needed for floating label animation measurement -->
+        <span id="floatedLabelText" class="label-text">{{label}}</span>
+      </div>
+    </template>
 
-    <div class="floated-label" aria-hidden="true" hidden?="{{!floatingLabel}}" invisible?="{{!floatingLabelVisible || labelAnimated}}">
-      <!-- needed for floating label animation measurement -->
-      <span id="floatedLabelText" class="label-text">{{label}}</span>
-    </div>
-
-    <div class="input-body" flex auto relative>
-
+    <div class="input-body" flex auto relative layout horizontal?="{{raised}}">
+      <template if="{{raised && !disabled}}">
+        <paper-shadow fit></paper-shadow>
+      </template>
       <div class="label" fit invisible aria-hidden="true">
         <!-- needed for floating label animation measurement -->
         <span id="labelText" class="label-text" invisible?="{{!_labelVisible}}" animated?="{{labelAnimated}}">{{label}}</span>
       </div>
-
+      
       <content select="*:not(.counter)"></content>
-
+      <template if="{{raised}}">
+        <div class="error" self-center layout horizontal center hidden?="{{!isInvalid}}">
+          <div class="error-text" flex auto role="alert" aria-hidden="{{!isInvalid}}">{{error}}</div>
+          <core-icon id="errorIcon" class="error-icon" icon="warning"></core-icon>
+        </div>
+      </template>
     </div>
-
-    <div id="underline" class="underline" relative>
-      <div class="unfocused-underline" fit invisible?="{{disabled}}"></div>
-      <div id="focusedUnderline" class="focused-underline" fit invisible?="{{!underlineVisible}}" animated?="{{underlineAnimated}}"></div>
-    </div>
-
-    <div class="footer" layout horizontal end-justified>
-      <div class="error" flex layout horizontal center hidden?="{{!isInvalid}}">
-        <div class="error-text" flex auto role="alert" aria-hidden="{{!isInvalid}}">{{error}}</div>
-        <core-icon id="errorIcon" class="error-icon" icon="warning"></core-icon>
+    <template if="{{!raised}}">
+      <div id="underline" class="underline" relative>
+        <div class="unfocused-underline" fit invisible?="{{disabled}}"></div>
+        <div id="focusedUnderline" class="focused-underline" fit invisible?="{{!underlineVisible}}" animated?="{{underlineAnimated}}"></div>
       </div>
-      <div aria-hidden="true">
-        <content select=".counter"></content>
+      
+      <div class="footer" layout horizontal end-justified>
+        <div class="error" flex layout horizontal center hidden?="{{!isInvalid}}">
+          <div class="error-text" flex auto role="alert" aria-hidden="{{!isInvalid}}">{{error}}</div>
+          <core-icon id="errorIcon" class="error-icon" icon="warning"></core-icon>
+        </div>
+        <div aria-hidden="true">
+          <content select=".counter"></content>
+        </div>
       </div>
-    </div>
-
+    </template>
+    
+    <template if="{{raised}}">
+      <style>
+        .input-body {
+          background-color:white;
+          padding:10px;
+          border-radius:2px;
+        }
+        .input-body paper-shadow {
+          border-radius:inherit;
+        }
+        
+        .error-text {
+          padding:0;
+        }
+      </style>
+      <template if="{{disabled}}">
+        <style>
+          .input-body {
+            background-color:#eee;
+          }
+        </style>
+      </template>
+    </template>
   </template>
 
   <script>
@@ -291,6 +324,15 @@ conflict with this element.
          * @default false
          */
         autoValidate: false,
+        /**
+         * Set this property to true to add a Material Design drop shadow to the input.
+         * 
+         *
+         * @attribute raised
+         * @type boolean
+         * @default false
+         */
+        raised: false,
 
         /**
          * The message to display if the input value fails validation. If this

--- a/paper-input.html
+++ b/paper-input.html
@@ -60,7 +60,7 @@ Use `paper-input-decorator` if you would like to implement validation.
     }
   </style>
 
-  <paper-input-decorator id="decorator" label="{{label}}" floatingLabel="{{floatingLabel}}" value="{{value}}" disabled?="{{disabled}}">
+  <paper-input-decorator id="decorator" label="{{label}}" floatingLabel="{{floatingLabel}}" value="{{value}}" disabled?="{{disabled}}" raised="{{raised}}">
     <input is="core-input" id="input" value="{{value}}" committedValue="{{committedValue}}" on-change="{{changeAction}}" disabled?="{{disabled}}">
   </paper-input-decorator>
 
@@ -116,7 +116,16 @@ Use `paper-input-decorator` if you would like to implement validation.
        * @type String
        * @default ''
        */
-      committedValue: ''
+      committedValue: '',
+      /**
+         * Set this property to true to add a Material Design drop shadow to the input.
+         * 
+         *
+         * @attribute raised
+         * @type boolean
+         * @default false
+         */
+      raised: false
 
     },
 


### PR DESCRIPTION
A raised input with a `<paper-shadow>`. This is seen in Android Lollipop, most notably the Google Now Launcher and settings search.
![image](https://cloud.githubusercontent.com/assets/8939680/6329608/83b41e94-bb37-11e4-9c18-218cbe87200c.png)
