### PR TITLE
Fix the paper-autogrow-textarea's update() docs

### DIFF
--- a/paper-autogrow-textarea.html
+++ b/paper-autogrow-textarea.html
@@ -25,7 +25,7 @@ Example:
 
     /* using example HTML above */
     t1.value = 'some\ntext';
-    a1.update();
+    a1.update(t1);
 
 @group Paper Elements
 @element paper-autogrow-textarea
@@ -139,7 +139,7 @@ Example:
     /**
      * Sizes this element to fit the input value. This function is automatically called
      * when the user types in new input, but you must call this function if the value
-     * is updated imperatively.
+     * is updated imperatively. Takes as parameter the textarea containing the input.
      *
      * @method update
      * @param Element The input


### PR DESCRIPTION
I've added a small note that `update()` takes a parameter, since the official docs don't show arguments to methods, and this has come up in several issues recently.