### PR TITLE
Documentation fix for focused CSS class name

### DIFF
--- a/paper-input-decorator.html
+++ b/paper-input-decorator.html
@@ -56,7 +56,7 @@ To add custom styling to only some elements, use these selectors:
         background-color: green;
     }
 
-    paper-input-decorator[focused] /deep/ .floating-label .label-text {
+    paper-input-decorator[focused] /deep/ .floated-label .label-text {
         /* floating label color when the input is focused */
         color: orange;
     }


### PR DESCRIPTION
`paper-input-decorator[focused]` had the wrong CSS class name in the
documentation. Changed from `floating-label` to `floated-label`.